### PR TITLE
Fixed unicode problems

### DIFF
--- a/alf_test.h
+++ b/alf_test.h
@@ -356,6 +356,12 @@ typedef struct AlfTestData
 
 // -------------------------------------------------------------------------- //
 
+/** Check that condition is true. Alias for the longer version 
+ * ALF_CHECK_TRUE **/
+#define ALF_CHECK(condition, ...) ALF_CHECK_TRUE(condition, (__VA_ARGS__))
+
+// -------------------------------------------------------------------------- //
+
 /** Check that condition is false **/
 #define ALF_CHECK_FALSE(condition, ...)										\
 	alfCheckFalse(															\

--- a/alf_unicode.c
+++ b/alf_unicode.c
@@ -66,7 +66,7 @@ uint32_t alfStringSize(const AlfChar8* string)
  * is expected to be valid. Validity is not checked by this function **/
 uint32_t alfUTF8CodepointWidthFromFirstByte(uint8_t c)
 {
-	return c <= 0x7F ? 1 : c <= 0x7FF ? 2 : c <= 0xFFFF ? 3 : 4;
+	return c < 0xC0 ? 1 : c < 0xE0 ? 2 : c < 0xF0 ? 3 : 4;
 }
 
 // ========================================================================== //
@@ -263,7 +263,7 @@ uint64_t alfUTF8StringLength(const AlfChar8* string)
 		offset += alfUTF8CodepointWidthFromFirstByte(c);
 		length++;
 	}
-	return length - 1;
+	return length;
 }
 
 // -------------------------------------------------------------------------- //
@@ -481,8 +481,6 @@ AlfChar8* alfUTF8Insert(
 		if (index == from) { startOffset = offset; }
 		if (index == from + count) { endOffset = offset; }
 	}
-
-	if (endOffset == 0) { return NULL; }
 
 	const uint64_t insertSize = alfStringSize(insertion);
 	const uint64_t beforeSize = startOffset;
@@ -725,7 +723,7 @@ uint64_t alfUTF16StringLength(const AlfChar16* string)
 		offset += alfUTF16CodepointWidthFromFirstByte(c);
 		length++;
 	}
-	return length - 1;
+	return length;
 }
 
 // -------------------------------------------------------------------------- //

--- a/tests/test.c
+++ b/tests/test.c
@@ -72,6 +72,30 @@ uint32_t numbers0through79[] = {
 // Unicode Tests
 // ========================================================================== //
 
+ALF_TEST(length, utf8)
+{
+	ALF_CHECK_TRUE(alfUTF8StringLength(u8"") == 0);
+	ALF_CHECK_TRUE(alfUTF8StringLength(u8"a") == 1);
+	ALF_CHECK_TRUE(alfUTF8StringLength(u8"ö") == 1);
+	ALF_CHECK_TRUE(alfUTF8StringLength(u8"åäö") == 3);
+	ALF_CHECK_TRUE(alfUTF8StringLength(u8"aö") == 2);
+	ALF_CHECK_TRUE(alfUTF8StringLength(u8"öa") == 2);
+	ALF_CHECK_TRUE(alfUTF8StringLength(NULL) == 0,
+		"NULL strings have a length of 0");
+}
+
+// -------------------------------------------------------------------------- //
+
+ALF_TEST(codepoint_width, utf8)
+{
+	ALF_CHECK_TRUE(alfUTF8CodepointWidth('a') == 1);
+	ALF_CHECK_TRUE(alfUTF8CodepointWidth(246) == 2); // ö
+	ALF_CHECK_TRUE(alfUTF8CodepointWidth(24328) == 3); // 弈
+	ALF_CHECK_TRUE(alfUTF8CodepointWidth(129300) == 4); // 🤔
+}
+
+// -------------------------------------------------------------------------- //
+
 ALF_TEST(insert, utf8)
 {
 	// Setup input strings
@@ -82,14 +106,38 @@ ALF_TEST(insert, utf8)
 	ALF_CHECK_STR_EQ(output0, u8"månadsdag",
 		"Add letters in word, no delete");
 
+	char* output1 = alfUTF8Insert(u8"", 0, 0, u8"månad");
+	ALF_CHECK_STR_EQ(output1, u8"månad",
+		"Insert into empty string");
+}
+
+// -------------------------------------------------------------------------- //
+
+ALF_TEST(delete, utf8)
+{
+	// Setup input strings
+	const char* input0 = u8"måndag";
+
 	// Delete
-	char* output1 = alfUTF8Insert(input0, 3, 3, u8"");
-	ALF_CHECK_STR_EQ(output1, u8"mån",
+	char* output0 = alfUTF8Insert(input0, 3, 3, u8"");
+	ALF_CHECK_STR_EQ(output0, u8"mån",
 		"Only delete letters, no adding");
 
+	char* output1 = alfUTF8Insert(u8"", 0, 0, u8"");
+	ALF_CHECK_STR_EQ(output0, u8"mån",
+		"Only delete letters, no adding");
+}
+
+// -------------------------------------------------------------------------- //
+
+ALF_TEST(replace, utf8)
+{
+	// Setup input strings
+	const char* input0 = u8"måndag";
+
 	// Replace
-	char* output2 = alfUTF8Insert(input0, 0, 3, u8"annan");
-	ALF_CHECK_STR_EQ(output2, u8"annandag",
+	char* output0 = alfUTF8Insert(input0, 0, 3, u8"annan");
+	ALF_CHECK_STR_EQ(output0, u8"annandag",
 		"Replace letters, delete some and add some");
 }
 
@@ -302,11 +350,15 @@ int main()
 
 	// Setup suite: Unicode
 	AlfTest testsUnicode[] = {
+		ALF_TEST_LISTING(length, utf8),
+		ALF_TEST_LISTING(codepoint_width, utf8),
 		ALF_TEST_LISTING(insert, utf8),
+		ALF_TEST_LISTING(delete, utf8),
+		ALF_TEST_LISTING(replace, utf8),
 		ALF_TEST_LISTING(substring, utf8)
 	};
 	AlfTestSuite* suiteUnicode =
-		alfCreateTestSuite("Unicode", testsUnicode, 2);
+		alfCreateTestSuite("Unicode", testsUnicode, 6);
 
 	// Setup suite: Thread
 	AlfTest testsThread[] = {


### PR DESCRIPTION
* Fixed a bug where the invalid length of a codepoint was returned from
the first byte of it's encoded value
* Fixed the wrong length (off by one, -1) being returned for both UTF-8
and UTF-16 strings
* Fixed not being able to insert into a UTF-8 string with the same
'from' and 'to' index.
* Added a utility macro for checking a condition to be true when
testing. This macro 'ALF_CHECK' is just an alias for 'ALF_CHECK_TRUE'

Fixes #13, fixes #14, and fixes #15 