### PR TITLE
Fixed tests that assumed wrong API

### DIFF
--- a/alf_unicode.c
+++ b/alf_unicode.c
@@ -482,6 +482,8 @@ AlfChar8* alfUTF8Insert(
 		if (index == from + count) { endOffset = offset; }
 	}
 
+	if (endOffset < startOffset) { return NULL; }
+
 	const uint64_t insertSize = alfStringSize(insertion);
 	const uint64_t beforeSize = startOffset;
 	const uint64_t afterSize = offset - endOffset;

--- a/tests/test.c
+++ b/tests/test.c
@@ -100,17 +100,17 @@ ALF_TEST(codepoint_width, utf8)
 
 ALF_TEST(insert, utf8)
 {
-	// Setup input strings
-	const char* input0 = "måndag";
-
 	// Insert
-	char* output0 = alfUTF8Insert(input0, 3, 0, "ads");
+	char* output0 = alfUTF8Insert("måndag", 3, 0, "ads");
 	ALF_CHECK_STR_EQ(output0, "månadsdag",
 		"Add letters in word, no delete");
 
 	char* output1 = alfUTF8Insert("", 0, 0, "månad");
 	ALF_CHECK_STR_EQ(output1, "månad",
 		"Insert into empty string");
+
+	char* output2 = alfUTF8Insert("T", 1, 0, "h");
+	ALF_CHECK_STR_EQ(output2, "Th");
 }
 
 // -------------------------------------------------------------------------- //


### PR DESCRIPTION
* Fixed tests that assumed that the third parameter to the insert
function was the end index. This however is wrong as this is actually
the count