### PR TITLE
Can now create threads on (modern) linux.

### DIFF
--- a/alf_thread.c
+++ b/alf_thread.c
@@ -853,10 +853,10 @@ alfSetThreadName(const char* name)
     // TODO(Filip Bj�rklund): Don't cut UTF-8 codepoints in half!
 
     // Set the thread name
-    pthread_setname_np(temp_name);
+    pthread_setname_np(thread, name, strlen(name));
   } else {
     // Set the thread name
-    pthread_setname_np(name);
+    pthread_setname_np(thread, name, strlen(name));
   }
 #endif
 


### PR DESCRIPTION
The function pthread_setname_np has the wrong signature. Changed it, and it now works. However, I'm not sure how this has not been a problem before?

source: http://man7.org/linux/man-pages/man3/pthread_setname_np.3.html